### PR TITLE
Allow downstream crates to decide on how rusqlite should be built

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ percent-encoding = "1"
 url = "1"
 log = "0.4"
 postgres = {version = "0.15", optional = true}
-rusqlite = {version = "0.13", optional = true, features = ["bundled"] }
+rusqlite = {version = "0.13", optional = true }
 mysql = { version = "12", optional = true }
 
 [features]


### PR DESCRIPTION
As cargo features are additive, using migrant_lib in a crate currently forces the crate to use bundled rusqlite.